### PR TITLE
Prefix on save

### DIFF
--- a/Autoprefixer.py
+++ b/Autoprefixer.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 import json
-from os.path import dirname, realpath, join
+from os.path import dirname, realpath, join, splitext
 
 try:
 	# Python 2
@@ -63,4 +63,4 @@ def get_setting(view, key):
 	return settings.get(key)
 
 def is_css(view):
-		return view.settings().get('syntax') == 'Packages/CSS/CSS.tmLanguage'
+	return splitext(view.settings().get('syntax'))[0] == 'Packages/CSS/CSS'

--- a/Autoprefixer.py
+++ b/Autoprefixer.py
@@ -35,8 +35,8 @@ class AutoprefixerCommand(sublime_plugin.TextCommand):
 	def prefix(self, data):
 		try:
 			return node_bridge(data, BIN_PATH, [json.dumps({
-				'browsers': AutoprefixerCommand.get_setting(self.view, 'browsers'),
-				'cascade': AutoprefixerCommand.get_setting(self.view, 'cascade')
+				'browsers': get_setting(self.view, 'browsers'),
+				'cascade': get_setting(self.view, 'cascade')
 			})])
 		except Exception as e:
 			sublime.error_message('Autoprefixer\n%s' % e)
@@ -48,24 +48,19 @@ class AutoprefixerCommand(sublime_plugin.TextCommand):
 				return True
 		return False
 
-	@staticmethod
-	def get_setting(view, key):
-		settings = view.settings().get('Autoprefixer')
-		if settings is None:
-			settings = sublime.load_settings('Autoprefixer.sublime-settings')
-		return settings.get(key)
 
 class AutoprefixerPreSaveCommand(sublime_plugin.EventListener):
 	def on_pre_save(self, view):
 
-		if AutoprefixerCommand.get_setting(view, 'prefixOnSave') is True:
-
-			if int(sublime.version()) >= 3080:
-				self.sublime_vars = view.window().extract_variables()
-			else:
-				self.sublime_vars = {
-					'file_extension': splitext(view.file_name())[1][1:]
-				}
-
-			if self.sublime_vars['file_extension'] in ('css'):
+		if get_setting(view, 'prefixOnSave') is True and is_css(view):
 				view.run_command('autoprefixer')
+
+
+def get_setting(view, key):
+	settings = view.settings().get('Autoprefixer')
+	if settings is None:
+		settings = sublime.load_settings('Autoprefixer.sublime-settings')
+	return settings.get(key)
+
+def is_css(view):
+		return view.settings().get('syntax') == 'Packages/CSS/CSS.tmLanguage'

--- a/Autoprefixer.py
+++ b/Autoprefixer.py
@@ -1,7 +1,7 @@
 import sublime
 import sublime_plugin
 import json
-from os.path import dirname, realpath, join, splitext
+from os.path import dirname, realpath, join, splitext, basename
 
 try:
 	# Python 2
@@ -63,4 +63,4 @@ def get_setting(view, key):
 	return settings.get(key)
 
 def is_css(view):
-	return splitext(view.settings().get('syntax'))[0] == 'Packages/CSS/CSS'
+	return splitext(basename(view.settings().get('syntax')))[0] == 'CSS'

--- a/Autoprefixer.sublime-settings
+++ b/Autoprefixer.sublime-settings
@@ -1,5 +1,6 @@
 {
 	"browsers": ["last 2 versions"],
 	"cascade": true,
-	"remove": true
+	"remove": true,
+	"prefixOnSave": false
 }

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,8 @@ See the [supported browser names](https://github.com/ai/autoprefixer#browsers).
 
 ```json
 {
-	"browsers": ["last 2 versions"]
+	"browsers": ["last 2 versions"],
+	"prefixOnSave": false
 }
 ```
 


### PR DESCRIPTION
Uses `on_pre_save` event to run autoprefix command on files with `.css` extension.

Add field in `Autoprefixer.sublime-settings`:
 ```json
 {
    "prefixOnSave": false
 }
 ```

-

Fixes #2.