### PR TITLE
Use Autoprefixer defaults browsers

### DIFF
--- a/Autoprefixer.sublime-settings
+++ b/Autoprefixer.sublime-settings
@@ -1,5 +1,5 @@
 {
-	"browsers": ["last 2 versions"],
+	"browsers": ["defaults"],
 	"cascade": true,
 	"remove": true,
 	"prefixOnSave": false

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ See the [supported browser names](https://github.com/postcss/autoprefixer#browse
 
 ```json
 {
-	"browsers": ["last 2 versions"],
+	"browsers": ["defaults"],
 	"prefixOnSave": false
 }
 ```


### PR DESCRIPTION
Right now this plugin uses different default browsers `last 2 version`, than Autoprefixer `last 2 version, > 1%, Firefox ESR`. As result, this plugin has [unexpected behavior](https://github.com/postcss/autoprefixer/issues/759).

I change default browsers to current Autoprefixer defaults. But maybe we need to bump Autoprefixer and Can I Use versions for it (anyway it is very important to any Autoprefixer runner to have latest versions).