### PR TITLE
Add support for flexbox and grid options and add documentation

### DIFF
--- a/Autoprefixer.py
+++ b/Autoprefixer.py
@@ -57,6 +57,9 @@ class AutoprefixerCommand(sublime_plugin.TextCommand):
 			return node_bridge(data, BIN_PATH, [json.dumps({
 				'browsers': get_setting(self.view, 'browsers'),
 				'cascade': get_setting(self.view, 'cascade'),
+				'remove': get_setting(self.view, 'remove'),
+				'flexbox': get_setting(self.view, 'flexbox'),
+				'grid': get_setting(self.view, 'grid'),
 				'is_css': is_css(self.view)
 			})])
 		except Exception as e:

--- a/Autoprefixer.sublime-settings
+++ b/Autoprefixer.sublime-settings
@@ -1,6 +1,17 @@
 {
+	// @see  Browserslist docs https://github.com/ai/browserslist#queries
 	"browsers": ["defaults"],
+	// Autoprefixer use Visual Cascade, if CSS is uncompressed
+	// boolean
 	"cascade": true,
+	// Autoprefixer [remove outdated] prefixes
+	// boolean
 	"remove": true,
+	// Autoprefixer add prefixes for flexbox properties
+	// boolean|string (no-2009)
+	"flexbox": true,
+	// Autoprefixer add IE prefixes for Grid Layout properties/
+	// boolean
+	"grid": true,
 	"prefixOnSave": false
 }


### PR DESCRIPTION
allow to use autoprefixer options like flexbox and grid.

example : 
{
    "browsers": ["> 0.7%", "last 1 version"],
    "flexbox": "no-2009",
    "prefixOnSave": true
}

without autoprefixer 
.example {
  display: flex;
  justify-content: space-between;
}

with autoprefixer and without flexbox "no-2009"
.example {
  display: -webkit-box;
  display: -webkit-flex;
  display: flex;
  -webkit-box-pack: justify;
  -webkit-justify-content: space-between;
          justify-content: space-between;
}

with autoprefixer and with flexbox "no-2009"
.example {
  display: -webkit-flex;
  display: flex;
  -webkit-justify-content: space-between;
  justify-content: space-between;
}